### PR TITLE
Validations on StartDateTime and EndDateTime

### DIFF
--- a/ARM Template/azuredeploy.json
+++ b/ARM Template/azuredeploy.json
@@ -98,7 +98,8 @@
                 "ClientID": "[parameters('appId')]",
                 "UserEmail": "[parameters('user_upn')]",
                 "UserPassword": "[concat('@Microsoft.KeyVault(SecretUri=',reference(concat('Microsoft.KeyVault/vaults/',parameters('keyvault_name'),'/secrets/',variables('userpassword_secret_name'))).secretUriWithVersion,')')]",
-                "DefaultMeetingName":"Default Meeting Name"
+                "DefaultMeetingName":"Default Meeting Name",
+                "DefaultMeetingDurationMins": 60
             }
         },
         {

--- a/Function/BookFunc/GenerateMeetingFunction.cs
+++ b/Function/BookFunc/GenerateMeetingFunction.cs
@@ -23,15 +23,17 @@ namespace TeamsMeetingBookingFunction
 			ILogger log)
 		{
 			
+			//StartDateTime is mandatory. Return BadRequest if not passed or if input format is invalid
 			if(!requestModel.StartDateTime.HasValue)
 			{
 				log.LogError($"{nameof(RequestModel.StartDateTime)} is null. Invalid format or parameter not passed. Returning BadRequest");
 				return new BadRequestErrorMessageResult($"{nameof(RequestModel.StartDateTime)} not present or invalid. Please use the format YYYY-mm-DDTHH:mm:ss");
 			}
 
-			requestModel.MeetingDurationMins = requestModel.MeetingDurationMins == 0 ? 
-				BookingService.Current.Configuration.GetValue<int>(ConfigConstants.DefaultMeetingDurationMinsCfg) : 
-				requestModel.MeetingDurationMins;
+			if(requestModel.MeetingDurationMins == 0)
+			{
+				requestModel.MeetingDurationMins = BookingService.Current.Configuration.GetValue<int>(ConfigConstants.DefaultMeetingDurationMinsCfg);
+			}
 
 			requestModel.Subject ??= BookingService.Current.Configuration.GetValue<string>(ConfigConstants.DefaultMeetingNameCfg);
 			

--- a/Function/BookFunc/GenerateMeetingFunction.cs
+++ b/Function/BookFunc/GenerateMeetingFunction.cs
@@ -59,7 +59,7 @@ namespace TeamsMeetingBookingFunction
 			{
 
 				log.LogError(e, "An error occurred invoking the Microsoft Graph API using StartDate = {startDate}, EndDate = {endDate}, Subject = {subject}",
-					requestModel.StartDateTime, requestModel.EndDateTime, requestModel.Subject);
+					requestModel.StartDateTime, requestModel.StartDateTime.Value.AddMinutes(requestModel.MeetingDurationMins), requestModel.Subject);
 
 				if (e.StatusCode == System.Net.HttpStatusCode.BadRequest)
 				{

--- a/Function/BookFunc/GenerateMeetingFunction.cs
+++ b/Function/BookFunc/GenerateMeetingFunction.cs
@@ -39,7 +39,7 @@ namespace TeamsMeetingBookingFunction
 			
 			try
 			{
-				log.LogInformation("Creating a meeting with following info: StartDateTime = {startDateTime}, DurationHours = {durationHours}, Subject = {subject}",
+				log.LogInformation("Creating a meeting with following info: StartDateTime = {startDateTime}, DurationHours = {durationMins}, Subject = {subject}",
 					requestModel.StartDateTime, requestModel.MeetingDurationMins, requestModel.Subject);
 				
 				var onlineMeeting = await BookingService.Current.CreateTeamsMeetingAsync(requestModel).ConfigureAwait(false);

--- a/Function/BookFunc/GenerateMeetingFunction.cs
+++ b/Function/BookFunc/GenerateMeetingFunction.cs
@@ -25,6 +25,7 @@ namespace TeamsMeetingBookingFunction
 			//You can't specify only EndDateTime
 			if (requestModel.EndDateTime != null && requestModel.StartDateTime == null)
 			{
+				log.LogError("Only EndDateTime has been passed in input. Returning BadRequest");
 				return new BadRequestErrorMessageResult($"If you specify {nameof(requestModel.EndDateTime)}, you must specify {nameof(requestModel.StartDateTime)} as well");
 			}
 
@@ -34,12 +35,17 @@ namespace TeamsMeetingBookingFunction
 
 			if (requestModel.EndDateTime.Value < requestModel.StartDateTime.Value)
 			{
+				log.LogError($"{nameof(requestModel.EndDateTime)} must be after {nameof(requestModel.StartDateTime)}. Returning BadRequest");
 				return new BadRequestErrorMessageResult($"{nameof(requestModel.EndDateTime)} must be after {nameof(requestModel.StartDateTime)}");
 			}
 			try
 			{
-
+				log.LogInformation("Creating a meeting with following info: StartDateTime = {startDateTime}, EndDateTime = {endDateTime}, Subject = {subject}",
+					requestModel.StartDateTime, requestModel.EndDateTime, requestModel.Subject);
+				
 				var onlineMeeting = await BookingService.Current.CreateTeamsMeetingAsync(requestModel).ConfigureAwait(false);
+				
+				log.LogInformation("Meeting created. MeetingUrl = {meetingUrl}, MeetingId = {meetingId}", onlineMeeting.JoinWebUrl, onlineMeeting.Id);
 
 				var result = new
 				{

--- a/Function/BookFunc/GenerateMeetingFunction.cs
+++ b/Function/BookFunc/GenerateMeetingFunction.cs
@@ -39,7 +39,7 @@ namespace TeamsMeetingBookingFunction
 			
 			try
 			{
-				log.LogInformation("Creating a meeting with following info: StartDateTime = {startDateTime}, DurationHours = {durationMins}, Subject = {subject}",
+				log.LogInformation("Creating a meeting with following info: StartDateTime = {startDateTime}, DurationMins = {durationMins}, Subject = {subject}",
 					requestModel.StartDateTime, requestModel.MeetingDurationMins, requestModel.Subject);
 				
 				var onlineMeeting = await BookingService.Current.CreateTeamsMeetingAsync(requestModel).ConfigureAwait(false);
@@ -58,8 +58,8 @@ namespace TeamsMeetingBookingFunction
 			catch (ServiceException e)
 			{
 
-				log.LogError(e, "An error occurred invoking the Microsoft Graph API using StartDate = {startDate}, EndDate = {endDate}, Subject = {subject}",
-					requestModel.StartDateTime, requestModel.StartDateTime.Value.AddMinutes(requestModel.MeetingDurationMins), requestModel.Subject);
+				log.LogError(e, "An error occurred invoking the Microsoft Graph API using StartDateTime = {startDateTime}, DurationMins = {durationMins}, Subject = {subject}",
+					requestModel.StartDateTime, requestModel.MeetingDurationMins, requestModel.Subject);
 
 				if (e.StatusCode == System.Net.HttpStatusCode.BadRequest)
 				{

--- a/Function/BookFunc/GenerateMeetingFunction.cs
+++ b/Function/BookFunc/GenerateMeetingFunction.cs
@@ -20,14 +20,16 @@ namespace TeamsMeetingBookingFunction
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)]
             RequestModel requestModel,
-            HttpRequest req,
-            ILogger log, ExecutionContext context)
+            ILogger log)
         {
-            // to fix : if you put startdate please check that enddate is > startdate
             requestModel.StartDateTime ??= DateTime.Now;
-            requestModel.EndDateTime ??= DateTime.Now.AddHours(1);
+            requestModel.EndDateTime ??= requestModel.StartDateTime.Value.AddHours(1);
             requestModel.Subject ??= BookingService.Current.Configuration.GetConnectionStringOrSetting(ConfigConstants.DefaultMeetingNameCfg);
 
+            if(requestModel.EndDateTime.Value < requestModel.StartDateTime.Value)
+            {
+                return new BadRequestErrorMessageResult($"{nameof(requestModel.EndDateTime)} must be after {nameof(requestModel.StartDateTime)}");
+            }
             try
             {
 

--- a/Function/BookFunc/GenerateMeetingFunction.cs
+++ b/Function/BookFunc/GenerateMeetingFunction.cs
@@ -52,8 +52,16 @@ namespace TeamsMeetingBookingFunction
 			}
 			catch (ServiceException e)
 			{
-				log.LogError($"Error:\n{e}");
-				return new BadRequestErrorMessageResult($"\"Can't perform request now - {e.Message}\"");
+
+				log.LogError(e, "An error occurred invoking the Microsoft Graph API using StartDate = {startDate}, EndDate = {endDate}, Subject = {subject}",
+					requestModel.StartDateTime, requestModel.EndDateTime, requestModel.Subject);
+
+				if (e.StatusCode == System.Net.HttpStatusCode.BadRequest)
+				{
+					return new BadRequestErrorMessageResult(e.Message);
+				}
+
+				return new InternalServerErrorResult();
 			}
 		}
 

--- a/Function/BookFunc/Helpers/Constants.cs
+++ b/Function/BookFunc/Helpers/Constants.cs
@@ -9,5 +9,6 @@
         internal const string UserPasswordCfg = "UserPassword";
         internal const string UserEmailCfg = "UserEmail";
         internal const string DefaultMeetingNameCfg = "DefaultMeetingName";
+        internal const string DefaultMeetingDurationMinsCfg = "DefaultMeetingDurationMins";
     }
 }

--- a/Function/BookFunc/Models/RequestModel.cs
+++ b/Function/BookFunc/Models/RequestModel.cs
@@ -6,7 +6,7 @@ namespace TeamsMeetingBookFunc.Models
     public class RequestModel
     {
         public DateTime? StartDateTime;
-        public DateTime? EndDateTime;
+        public int MeetingDurationMins;
         public string Subject;
         public string PatientEmailAddress;
         public string DoctorEmailAddress;

--- a/Function/BookFunc/Services/BookingService.cs
+++ b/Function/BookFunc/Services/BookingService.cs
@@ -56,7 +56,7 @@ namespace TeamsMeetingBookFunc.Services
             var onlineMeeting = new OnlineMeeting
             {
                 StartDateTime = requestModel.StartDateTime,
-                EndDateTime = requestModel.EndDateTime,
+                EndDateTime = requestModel.StartDateTime.Value.AddMinutes(requestModel.MeetingDurationMins),
                 Subject = requestModel.Subject
             };
 


### PR DESCRIPTION
fixes #8 

BTW, we still have a problem: if StartDateTime and/or EndDateTime are passed in a wrong format, we will use default values.

Example input body:
```json
{
   "StartDateTime" : "2020-04-08wrongformat"
}
```
We will create a meeting starting NOW and ending after 1 hour. This is wrong, and clearly is not what user wanted. Tracked in issue #10 